### PR TITLE
fixed bug: SyntaxError: invalid syntax

### DIFF
--- a/halite/server_bottle.py
+++ b/halite/server_bottle.py
@@ -104,7 +104,7 @@ def loadWebUI(app, devel=False, coffee=False):
         Echos back query args and content
         '''
         #convert to json serializible dict
-        query = { key: val for key, val in bottle.request.query.items()}
+        query = dict(bottle.request.query.items())
 
         data = dict(verb='GET',
                     url=bottle.request.url,


### PR DESCRIPTION
Traceback (most recent call last):
  File "test_server_start.py", line 7, in <module>
    halite.start(debug=True)
  File "/root/halite/halite/**init**.py", line 23, in start
    from . import server_bottle
  File "/root/halite/halite/server_bottle.py", line 107
    query = { key: val for key, val in bottle.request.query.items()}
                         ^
        for route in currentApp.routes
